### PR TITLE
Add SchnorrSignature type with parsing and serialization

### DIFF
--- a/libsecp256k1.cabal
+++ b/libsecp256k1.cabal
@@ -47,6 +47,7 @@ library
     , hashable >=1.4.2 && <1.5
     , hedgehog >=1.2 && <1.5
     , memory >=0.14.15 && <1.0
+    , random >=1.2.1.2 && <1.3
     , transformers >=0.4.0.0 && <1.0
   default-language: Haskell2010
 

--- a/libsecp256k1.cabal
+++ b/libsecp256k1.cabal
@@ -80,5 +80,6 @@ test-suite spec
     , libsecp256k1
     , memory >=0.14.15 && <1.0
     , monad-par
+    , random >=1.2.1.2 && <1.3
     , transformers >=0.4.0.0 && <1.0
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
   - hashable >=1.4.2 && <1.5
   - hedgehog >= 1.2 && <1.5
   - memory >= 0.14.15 && <1.0
+  - random >=1.2.1.2 && <1.3
   - transformers >= 0.4.0.0 && <1.0
 default-extensions:
   - ImportQualifiedPost


### PR DESCRIPTION
- Introduced SchnorrSignature type with parsing and serialization functions.

resolves https://github.com/haskell-bitcoin/libsecp256k1-haskell/issues/8