### PR TITLE
C shim for static context to address Windows MinGW64 runtime failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,17 +46,17 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@v4
         name: Checkout
 
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@v4
         name: Checkout bitcoin-core/secp256k1
         with:
           repository: bitcoin-core/secp256k1
-          ref: 1ad5185cd42c0636104129fcc9f6a4bf9c67cc40
+          ref: v0.5.1
           path: lib/secp256k1
 
-      - uses: haskell-actions/setup@64aa5146ed5bd91f181552b8b5fbe50fbd2bd3fe
+      - uses: haskell-actions/setup@v2
         name: Setup Haskell
         id: setup-haskell
         with:
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache
         id: cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ${{ steps.setup-haskell.outputs.stack-root }}

--- a/cbits/hs_secp256k1_shim.c
+++ b/cbits/hs_secp256k1_shim.c
@@ -1,0 +1,7 @@
+#include <secp256k1.h>
+
+/* Returns the adress of the library's built-in context */
+const secp256k1_context* hs_secp256k1_content_static(void)
+{
+    return secp256k1_context_static;
+}

--- a/libsecp256k1.cabal
+++ b/libsecp256k1.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           libsecp256k1
-version:        0.2.1
+version:        0.3.1
 synopsis:       Bindings for secp256k1
 description:    Sign and verify signatures using the secp256k1 library.
 category:       Crypto
@@ -35,6 +35,8 @@ library
       Paths_libsecp256k1
   hs-source-dirs:
       src
+  c-sources:
+      cbits/hs_secp256k1_shim.c
   default-extensions:
       ImportQualifiedPost
   pkgconfig-depends:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: libsecp256k1
-version: 0.2.1
+version: 0.3.1
 synopsis: Bindings for secp256k1
 description: Sign and verify signatures using the secp256k1 library.
 category: Crypto

--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,10 @@ library:
   source-dirs: src
   pkg-config-dependencies:
     - libsecp256k1
+  hs-source-dirs:
+    src
+  c-sources:
+    cbits/hs_secp256k1_shim.c
 tests:
   spec:
     main: Main.hs

--- a/src/Crypto/Secp256k1/Prim.hs
+++ b/src/Crypto/Secp256k1/Prim.hs
@@ -302,8 +302,12 @@ foreign import capi safe "secp256k1.h secp256k1_context_destroy"
 --  type serialization/parsing functions which require a context object to maintain
 --  API consistency, but currently do not require expensive precomputations or dynamic
 --  allocations.
-foreign import ccall unsafe "secp256k1.h secp256k1_context_no_precomp"
-    contextNoPrecomp :: Ctx
+foreign import ccall unsafe "hs_secp256k1_content_static"
+    c_contextStatic :: IO Ctx
+
+{-# NOINLINE contextStatic #-}
+contextStatic :: Ctx
+contextStatic = unsafePerformIO c_contextStatic
 
 
 -- | Copy a secp256k1 context object into caller-provided memory.
@@ -445,7 +449,7 @@ foreign import capi safe "secp256k1.h secp256k1_context_set_error_callback"
 --  undefined.
 --
 --  When this function has not been called (or called with fn==NULL), then the
---  default handler will be used. The library provides a default handler which
+--  default handler will be used. The library provides a default handler which
 --  writes the message to stderr and calls abort. This default handler can be
 --  replaced at link time if the preprocessor macro
 --  USE_EXTERNAL_DEFAULT_CALLBACKS is defined, which is the case if the build


### PR DESCRIPTION
This change attempts to address a Windows MinGW64 runtime failure that occurs during testing, where we see a "32 bit pseudo relocation out of range" error. The error suggests an issue with how GHC handles pointers in Windows executables.

1. Adds a C shim (hs_secp256k1_shim.c) to handle the static context
2. Updates the Haskell FFI bindings to use the shim instead of direct access
3. Bumps version to 0.3.1 to reflect the FFI interface change